### PR TITLE
Adds tidy() to QR decomposition function

### DIFF
--- a/src/backend/tfjs_backend.ts
+++ b/src/backend/tfjs_backend.ts
@@ -1122,67 +1122,73 @@ export function sign(x: Tensor): Tensor {
  * @throws ValueError if `x.shape[0] < x.shape[1]`, or if `x`'s rank is not 2.
  */
 export function qr(x: Tensor2D): [Tensor, Tensor] {
-  // TODO(cais): Extend support to >2D as in `tf.qr` and move this function to
-  //   the core.
-  if (x.shape.length !== 2) {
-    throw new ValueError(
-        `qr() requires a 2D Tensor, but got a ${x.shape.length}D Tensor.`);
-  }
-  if (x.shape[0] < x.shape[1]) {
-    throw new ValueError(
-        `qr() requires x.shape[0] >= x.shape[1], but got shape: [${x.shape}]`);
-  }
+  return tidy(() => {
+           // TODO(cais): Extend support to >2D as in `tf.qr` and move this
+           // function to
+           //   the core.
+           if (x.shape.length !== 2) {
+             throw new ValueError(`qr() requires a 2D Tensor, but got a ${
+                 x.shape.length}D Tensor.`);
+           }
+           if (x.shape[0] < x.shape[1]) {
+             throw new ValueError(
+                 `qr() requires x.shape[0] >= x.shape[1], but got shape: [${
+                     x.shape}]`);
+           }
 
-  const m = x.shape[0];
-  const n = x.shape[1];
+           const m = x.shape[0];
+           const n = x.shape[1];
 
-  let q = eye(m) as Tensor2D;  // Orthogonal transform so far.
-  let r = x;                   // Transformed matrix so far.
+           let q = eye(m) as Tensor2D;  // Orthogonal transform so far.
+           let r = x;                   // Transformed matrix so far.
 
-  const one2D = tensor2d([[1]], [1, 1]);
-  for (let j = 0; j < n; ++j) {
-    // Find H = I - tau * w * w', to put zeros below R(j, j).
-    const rjEnd1 = r.slice([j, j], [m - j, 1]);
-    const normX = tfc.norm(rjEnd1);
-    const rjj = r.slice([j, j], [1, 1]);
-    const s = tfc.neg(sign(rjj)) as Tensor2D;
-    const u1 = rjj.sub(multiply(s, normX)) as Tensor2D;
-    const wPre = divide(rjEnd1, u1);
-    let w: Tensor2D;
-    if (wPre.shape[0] === 1) {
-      w = one2D;
-    } else {
-      w = one2D.concat(
-              wPre.slice([1, 0], [wPre.shape[0] - 1, wPre.shape[1]]), 0) as
-          Tensor2D;
-    }
-    const tau = tfc.neg(divide(tfc.matMul(s, u1), normX)) as Tensor2D;
+           const one2D = tensor2d([[1]], [1, 1]);
+           for (let j = 0; j < n; ++j) {
+             // Find H = I - tau * w * w', to put zeros below R(j, j).
+             const rjEnd1 = r.slice([j, j], [m - j, 1]);
+             const normX = tfc.norm(rjEnd1);
+             const rjj = r.slice([j, j], [1, 1]);
+             const s = tfc.neg(sign(rjj)) as Tensor2D;
+             const u1 = rjj.sub(multiply(s, normX)) as Tensor2D;
+             const wPre = divide(rjEnd1, u1);
+             let w: Tensor2D;
+             if (wPre.shape[0] === 1) {
+               w = one2D;
+             } else {
+               w = one2D.concat(
+                       wPre.slice([1, 0], [wPre.shape[0] - 1, wPre.shape[1]]),
+                       0) as Tensor2D;
+             }
+             const tau = tfc.neg(divide(tfc.matMul(s, u1), normX)) as Tensor2D;
 
-    // -- R := HR, Q := QH.
-    const rjEndAll = r.slice([j, 0], [m - j, n]);
-    const tauTimesW = tau.mul(w) as Tensor2D;
-    if (j === 0) {
-      r = rjEndAll.sub(tauTimesW.matMul(w.transpose().matMul(rjEndAll)));
-    } else {
-      r = r.slice([0, 0], [j, n])
-              .concat(
-                  rjEndAll.sub(
-                      tauTimesW.matMul(w.transpose().matMul(rjEndAll))),
-                  0) as Tensor2D;
-    }
-    const qAllJEnd = q.slice([0, j], [m, q.shape[1] - j]);
-    if (j === 0) {
-      q = qAllJEnd.sub(qAllJEnd.matMul(w).matMul(tauTimesW.transpose()));
-    } else {
-      q = q.slice([0, 0], [m, j])
-              .concat(
-                  qAllJEnd.sub(
-                      qAllJEnd.matMul(w).matMul(tauTimesW.transpose())),
-                  1) as Tensor2D;
-    }
-  }
+             // -- R := HR, Q := QH.
+             const rjEndAll = r.slice([j, 0], [m - j, n]);
+             const tauTimesW = tau.mul(w) as Tensor2D;
+             if (j === 0) {
+               r = rjEndAll.sub(
+                   tauTimesW.matMul(w.transpose().matMul(rjEndAll)));
+             } else {
+               r = r.slice([0, 0], [j, n])
+                       .concat(
+                           rjEndAll.sub(tauTimesW.matMul(
+                               w.transpose().matMul(rjEndAll))),
+                           0) as Tensor2D;
+             }
+             const qAllJEnd = q.slice([0, j], [m, q.shape[1] - j]);
+             if (j === 0) {
+               q = qAllJEnd.sub(
+                   qAllJEnd.matMul(w).matMul(tauTimesW.transpose()));
+             } else {
+               q = q.slice([0, 0], [m, j])
+                       .concat(
+                           qAllJEnd.sub(qAllJEnd.matMul(w).matMul(
+                               tauTimesW.transpose())),
+                           1) as Tensor2D;
+             }
+           }
 
-  return [q, r];
+           return [q, r];
+         }) as [Tensor, Tensor];
 }
 
 /**


### PR DESCRIPTION
Possibly addresses issue #245.

Checked that fewer Tensors were allocated during tests (6 vs. 70 for a very small problem).